### PR TITLE
bump dependencies & publish to bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,40 @@
-name := "oauth2.0-scala"
-
-scalaVersion in ThisBuild := "2.11.7"
-
-organization in ThisBuild := "io.github.algd"
-
-version in ThisBuild := "0.3.0-SNAPSHOT"
-
-scalacOptions in ThisBuild := Seq("-unchecked", "-deprecation", "-target:jvm-1.8", "-encoding", "utf8", "-feature")
+lazy val commonSettings = Seq(
+  organization := "io.github.algd",
+  version := "0.4.0",
+  licenses := Seq(("Apache-2.0", url("https://spdx.org/licenses/Apache-2.0.html"))),
+  scmInfo := Some(ScmInfo(
+    browseUrl = url("https://github.com/algd/oauth2.0-scala"),
+    connection = "scm:git:git@github.com:algd/oauth2.0-scala.git"
+  )),
+  scalaVersion := "2.11.8",
+  scalacOptions := Seq(
+    "-unchecked",
+    "-deprecation",
+    "-target:jvm-1.8",
+    "-encoding", "utf8",
+    "-feature"
+  )
+)
 
 lazy val root = (project in file("."))
-  .aggregate(
-    `oauth2-scala-core`,
-    `oauth2-scala-akka-http`)
-  .settings(
-    publishArtifact := false
-  )
+  .settings(commonSettings)
+  .settings(name := "oauth2.0-scala")
+  .aggregate(`oauth2-scala-core`, `oauth2-scala-akka-http`)
+  .dependsOn(`oauth2-scala-core`, `oauth2-scala-akka-http`)
 
 lazy val `oauth2-scala-core` = project
+  .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-        "com.github.nscala-time" %% "nscala-time" % "2.6.0",
-        "org.scalatest"          %% "scalatest"   % "2.2.6" % "test")
+      "com.github.nscala-time" %% "nscala-time" % "2.12.0",
+      "org.scalatest"          %% "scalatest"   % "2.2.6" % "test"
+    )
   )
 
 lazy val `oauth2-scala-akka-http` = project
+  .settings(commonSettings)
   .settings(
     mainClass in Compile := None,
     libraryDependencies +=
-      "com.typesafe.akka" %% "akka-http-experimental" % "2.0.1"
+      "com.typesafe.akka" %% "akka-http-experimental" % "2.4.4"
   ).dependsOn(`oauth2-scala-core`)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
First time:
1. [create a Bintray account](https://bintray.com/signup/index)
2. get your api key (SHA1) at [profile/edit](https://bintray.com/profile/edit) (it look like this: da39a3ee5e6b4b0d3255bfef95601890afd80709)
3. set your user and api key with `sbt bintrayChangeCredentials`

For each release:
1. `sbt publish`

When you published this artifact you can get it via:

``` scala
resolvers += "bintray <username>" at "http://dl.bintray.com/content/<username>/maven"
libraryDependencies += "io.github.algd" %% "oauth2-scala-akka-http" % "<version>"
```

For now I published version 0.4.0 under my username

``` scala
resolvers += "bintray masseguillaume" at "http://dl.bintray.com/content/masseguillaume/maven"
libraryDependencies += "io.github.algd" %% "oauth2-scala-akka-http" % "0.4.0"
```
